### PR TITLE
Liedle help dialogue closes #18

### DIFF
--- a/cypress/e2e/liedle/colour-word.cy.js
+++ b/cypress/e2e/liedle/colour-word.cy.js
@@ -3,6 +3,7 @@ const word = "stare"
 describe('colour each letter based on if it matches the secret word', () => {
     beforeEach(() => {
         cy.visit("http://localhost:1234/liedle/index.html")
+        cy.get('[id=close-btn]').click()
         // override global variables for testing purposes
         cy.window().then((win) => {
             win.secretWord = word
@@ -30,6 +31,7 @@ describe('colour each letter based on if it matches the secret word', () => {
 describe('game has a chance of incorrectly colouring each letter', () => {
     beforeEach(() => {
         cy.visit("http://localhost:1234/liedle/index.html")
+        cy.get('[id=close-btn]').click()
         // override global variables for testing purposes
         cy.window().then((win) => {
             win.secretWord = word

--- a/cypress/e2e/liedle/end-game.cy.js
+++ b/cypress/e2e/liedle/end-game.cy.js
@@ -5,6 +5,7 @@ const NUM_COLS = 5
 describe('end game', () => {
     beforeEach(() => {
         cy.visit('http://localhost:1234/liedle/index.html')
+        cy.get('[id=close-btn]').click()
         // override global variables for testing purposes
         cy.window().then((win) => {
             win.secretWord = word

--- a/cypress/e2e/liedle/input.cy.js
+++ b/cypress/e2e/liedle/input.cy.js
@@ -5,6 +5,7 @@ const NUM_COLS = 5
 describe('characters', () => {
 	beforeEach(() => {
 		cy.visit("http://localhost:1234/liedle/index.html");
+		cy.get('[id=close-btn]').click()
 	})
 
 	it('test letter', () => {
@@ -49,6 +50,7 @@ describe('characters', () => {
 describe('backspace', () => {
 	beforeEach(() => {
 		cy.visit("http://localhost:1234/liedle/index.html");
+		cy.get('[id=close-btn]').click()
 	})
 
 	it('test backspace after letter', () => {
@@ -97,6 +99,7 @@ describe('backspace', () => {
 describe('enter', () => {
 	beforeEach(() => {
 		cy.visit("http://localhost:1234/liedle/index.html");
+		cy.get('[id=close-btn]').click()
 	})
 
 	it('test enter valid word and type', () => {

--- a/cypress/e2e/liedle/start.cy.js
+++ b/cypress/e2e/liedle/start.cy.js
@@ -1,15 +1,16 @@
 describe('initialise grid', () => {
   beforeEach(() => {
     cy.visit("http://localhost:1234/liedle/index.html");
+    cy.get('[id=close-btn]').click()
   })
 
   it('test grid full', () => {
-    cy.get('.tile')
+    cy.get('.tile').not(`[data-size=small]`)
       .should('have.length', 40)
   })
 
   it('test initial tile type', () => {
-    cy.get('.tile').first()
+    cy.get('.tile').not(`[data-size=small]`).first()
       .should('have.attr', 'data-type', 'empty')
   })
 })
@@ -17,10 +18,35 @@ describe('initialise grid', () => {
 describe('end game components', () => {
   beforeEach(() => {
     cy.visit("http://localhost:1234/liedle/index.html");
+    cy.get('[id=close-btn]').click()
   })
 
   it('end game messages hidden', () => {
-    cy.get('[id=end]')
+    cy.get('[id=end]').not(`[data-size=small]`)
       .should('have.css', 'visibility', 'hidden')
+  })
+})
+
+describe('help window', () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:1234/liedle/index.html");
+  })
+
+  it('test help window shows', () => {
+    cy.get('[id=modal]')
+      .should('have.css', 'display', 'block')
+  })
+
+  it('test help window closes', () => {
+    cy.get('[id=close-btn]').click()
+    cy.get('[id=modal]')
+      .should('have.css', 'display', 'none')
+  })
+
+  it('test help window opens', () => {
+    cy.get('[id=close-btn]').click()
+    cy.get('[id=help-btn]').click()
+    cy.get('[id=modal]')
+      .should('have.css', 'display', 'block')
   })
 })

--- a/src/liedle/index.html
+++ b/src/liedle/index.html
@@ -7,7 +7,43 @@
 		<link rel="stylesheet" href="liedle.css">
 	</head>
 	<body>
+
+	<!-- Navigation bar with back and help links -->
     <core-navbar>Liedle</core-navbar>
+
+	<!-- Modal window with instructions on how to play -->
+	<core-modal>
+		<div class="modal-header">HOW TO PLAY LIEDLE</div>
+		<p class="modal-text">Guess the secret word in 8 guesses. 
+			<br> Type in a word and press the enter key to submit. 
+			<br> Each guess must be a 5-letter word. </p>
+		<div id="word-grid" class="grid">
+			<div data-size="small" data-type="wrong" class="tile">w</div>
+			<div data-size="small" data-type="right" class="tile">a</div>
+			<div data-size="small" data-type="right-letter" class="tile">t</div>
+			<div data-size="small" data-type="wrong" class="tile">e</div>
+			<div data-size="small" data-type="wrong" class="tile">r</div>
+		</div>
+		<p class="modal-text">The green tile shows that the letter A is in the right place. 
+			<br> The yellow tile shows that the letter T is in the word, but not in the right place.</p>
+		<div id="word-grid" class="grid">
+			<div data-size="small" data-type="right" class="tile">m</div>
+			<div data-size="small" data-type="right" class="tile">a</div>
+			<div data-size="small" data-type="wrong" class="tile">n</div>
+			<div data-size="small" data-type="right-letter" class="tile">g</div>
+			<div data-size="small" data-type="wrong" class="tile">o</div>
+		</div>
+		<div id="word-grid" class="grid">
+			<div data-size="small" data-type="right" class="tile">m</div>
+			<div data-size="small" data-type="right" class="tile">a</div>
+			<div data-size="small" data-type="wrong" class="tile">n</div>
+			<div data-size="small" data-type="wrong" class="tile">g</div>
+			<div data-size="small" data-type="wrong" class="tile">o</div>
+		</div>
+		<p class="modal-text">Is the letter G in the word? <br> Sometimes the game will lie about the tile colour! </p>
+	</core-modal>
+
+		<!-- Website content starts here -->
 		<div class="content">
 			<div class="header">Liedle</div>
 			<div id="grid" class="grid"></div>
@@ -16,7 +52,9 @@
 				<div data-result id="end-message">placeholder</div>
 				<div id="word-reveal">placeholder</div>
 		</div>
+		
     <script type="module" src="../main.js"></script>
-		<script type="module" src="script.js"></script>
+    <script type="module" src="../modal-script.js"></script>
+	<script type="module" src="script.js"></script>
 	</body>
 </html>

--- a/src/liedle/liedle.css
+++ b/src/liedle/liedle.css
@@ -25,11 +25,20 @@ body {
     display: grid;
 }
 
+/* 5 x 8 grid of tiles */
 #grid {
     grid-template-rows: repeat(8, 64px);
     grid-template-columns: repeat(5, 64px);
     margin: 24px;
 }
+
+/* 5 x 1 grid of tiles representing a word */
+#word-grid {
+    grid-template-rows: repeat(1, 48px);
+    grid-template-columns: repeat(5, 48px);
+    margin: 16px;
+}
+
 
 /* tiles and tile variations */
 .tile {
@@ -68,6 +77,12 @@ body {
     background-color: #787c7e;
     color: white;
     border: none;
+}
+
+.tile[data-size="small"] {
+    font-size: 24px;
+    border-radius: 4px;
+    margin: 2px;
 }
 
 /* end game components */

--- a/src/main.css
+++ b/src/main.css
@@ -35,3 +35,56 @@ core-navbar a:active {
 core-navbar > div {
   padding: 8px;
 }
+
+/* the modal window used in all mini games */
+#modal {
+  position: fixed; 
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
+}
+
+.modal-window {
+  padding: 24px;
+  margin-top: 80px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2), 0 6px 6px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  font-size: 24px;
+  text-align: center;
+  margin-bottom: 36px;
+}
+
+.modal-text {
+  margin-bottom: 32px;
+  margin-left: 16px;
+  font-size: 16px;
+  line-height: 20px;
+  
+}
+
+#close-btn {
+  color: #787c7e;
+  position: fixed;
+  top: 16px;
+  right: 24px;
+  font-size: 32px;
+}
+
+#close-btn:hover,
+#close-btn:focus {
+color: #000;
+text-decoration: none;
+cursor: pointer;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,2 +1,3 @@
 // import custom components to register them
 import "./navbar";
+import "./modal";

--- a/src/modal-script.js
+++ b/src/modal-script.js
@@ -1,0 +1,26 @@
+const modal = document.getElementById("modal")
+const helpBtn = document.getElementById("help-btn")
+const closeBtn = document.getElementById("close-btn")
+
+function closeModal() {
+    modal.style.display = "none"
+}
+
+function openModal() {
+    modal.style.display = "block"
+}
+
+closeBtn.onclick = function () {
+    closeModal()
+}
+
+helpBtn.onclick = function () {
+    openModal()
+}
+
+// close window if they user clicks outside of the window
+window.onclick = function (event) {
+    if (event.target == modal) {
+        closeModal()
+    }
+}

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,0 +1,22 @@
+/** usage: <core-modal>Window contents</core-modal> */
+class Modal extends HTMLElement {
+	constructor() {
+		super();
+
+		// if you use `<core-modal custom>`, this component does nothing
+		if (this.getAttribute("custom") !== null) return;
+
+		this.innerHTML = `
+			<div>
+				<div id="modal">
+					<div class="modal-window">
+						<span id="close-btn">&times;</span>
+						<div>${this.innerHTML}</div>
+					</div>
+				</div>
+			</div>
+			`;
+	}
+}
+
+window.customElements.define("core-modal", Modal);

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -9,7 +9,7 @@ class Navbar extends HTMLElement {
     this.innerHTML = `
       <div><a href="../index.html">⬅️</a></div>
       <div>${this.innerHTML}</div>
-      <div><a href="#">❔</a></div>
+      <div id="help-btn"><a href="#">❔</a></div>
     `;
   }
 }


### PR DESCRIPTION
Related to #63
Implemented as a custom component in `src` so it can be reused in Capidle and 2048 Expert. The script for opening and closing the window is included as well. The modal window contents can be customised with innerHTML.
The win/lose message is hidden with the CSS `display` property by setting it to `block`/`none` so it doesn't "jiggle" the screen contents by taking up space when it is not visible. 
A separate addition `data-*` attribute was added for the mini tiles displayed on the window. 

![image](https://user-images.githubusercontent.com/78716153/184281713-afa376d5-951a-4d7e-a3c4-a06df3d829ce.png)
