### PR TITLE
add the standard navbar to 2048 expert

### DIFF
--- a/cypress/e2e/liedle/end-game.cy.js
+++ b/cypress/e2e/liedle/end-game.cy.js
@@ -92,11 +92,11 @@ describe('end game', () => {
         it('test play game after reset', () => {
             cy.get('body').type(word).type('{enter}')
             cy.get('[id=replay]').click()
-            cy.get('body').type(word).type('{enter}')
+            cy.get('body').type('frame').type('{enter}')
             cy.get('body').type('X')
 
             cy.get(`[data-col-index=0][data-row-index=0].tile`).first()
-                .should('have.text', 'S')
+                .should('have.text', 'F')
             cy.get(`[data-col-index=0][data-row-index=1].tile`).first()
                 .should('have.text', 'X')
         })

--- a/src/2048-expert/2048-expert.css
+++ b/src/2048-expert/2048-expert.css
@@ -12,8 +12,6 @@
  body {
    height: 100%;
    width: 100%;
-   display: flex;
-   justify-content: center;
    background-color: #faf8f0;
    font-size: 16px;
  }
@@ -26,7 +24,7 @@ h1 {
  /* Content Wrapper*/
  .container {
    width: 600px;
-   margin-top: 20px;
+   margin: 20px auto;
  }
 
  /* display scores */

--- a/src/2048-expert/index.html
+++ b/src/2048-expert/index.html
@@ -12,6 +12,8 @@
 </head>
 
 <body>
+	<core-navbar>2048 Expert</core-navbar>
+
     <!--Content Wrapper-->
     <div class="container">
         <div class="title">
@@ -36,6 +38,7 @@
         <div class="game-board"></div>
     </div>
 
+    <script type="module" src="../main.js"></script>
 </body>
 
 


### PR DESCRIPTION
Closes #66. 

This is a very simple PR. The standard navbar has been added to the 2048-expert mini game, so we now use the same navbar on all pages. Some minor css changes were required. 