### PR TITLE
create autocomplete for Capidle closes #32

### DIFF
--- a/cypress/e2e/capidle/autofill.cy.js
+++ b/cypress/e2e/capidle/autofill.cy.js
@@ -1,0 +1,75 @@
+/// <reference types="cypress" />
+
+describe("capidle autofill", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:1234/capidle?test");
+    cy.get("[id=close-btn]").click();
+  });
+
+  it("shows the autofill popup when the user types", () => {
+    // popup is hidden by default
+    cy.get(".autofill-popup").should("not.exist");
+
+    // type in a guess (which is spelt wrong)
+    cy.get("input[type=text]").type("Otā");
+
+    // there should be 3 suggestions in the autofill popup, inspite of the spelling mistake
+    cy.get(".autofill-popup > div").should("have.length", 3);
+
+    // We typed "Otā" and "Christchurch" is one of the suggested values.
+    // This is expected, because its te reo name is Ōtautahi.
+    cy.get(".autofill-popup > div").first().should("have.text", "Christchurch");
+    cy.get(".autofill-popup > div").eq(1).should("have.text", "Ōtaki");
+    cy.get(".autofill-popup > div").last().should("have.text", "Ōtaki Beach");
+
+    // none of the suggestions are "active" yet
+    cy.get(".active").should("not.exist");
+
+    // press the down arrow. Now the first option (Christchurch) should be active
+    cy.get("input[type=text]").type("{downarrow}");
+    cy.get(".active").should("have.text", "Christchurch");
+
+    // press the up arrow. since we're at the top of the list, this has no effect
+    cy.get("input[type=text]").type("{uparrow}");
+    cy.get(".active").should("have.text", "Christchurch");
+
+    // push the down arrow twice. now the last option should be selected
+    cy.get("input[type=text]").type("{downarrow}{downarrow}");
+    cy.get(".active").should("have.text", "Ōtaki Beach");
+
+    // push the down arrow again. Since we're at the bottom of the list, this has no effect
+    cy.get("input[type=text]").type("{downarrow}");
+    cy.get(".active").should("have.text", "Ōtaki Beach");
+
+    // press enter. The popup will close and the value will be inserted into the text field
+    cy.get("input[type=text]").type("{enter}");
+    cy.get(".autofill-popup").should("not.exist");
+    cy.get("input[type=text]").should("have.value", "Ōtaki Beach");
+
+    // press enter again. This will submit the guess, and clear the input field
+    cy.get("input[type=text]").type("{enter}");
+    cy.get(".autofill-popup").should("not.exist");
+    cy.get("input[type=text]").should("have.value", "");
+  });
+
+  it("supports touch interaction", () => {
+    // the previous test used arrow keys/enter, now we'll try clicking an option
+    cy.get("input[type=text]").type("Ōtepoti");
+    cy.get(".autofill-popup > div").should("have.length", 1);
+    cy.get(".autofill-popup > div").first().click();
+
+    cy.get(".autofill-popup").should("not.exist");
+    cy.get("input[type=text]").should("have.value", "Dunedin");
+  });
+
+  it("disables the submit button if the current form value is invalid", () => {
+    // disabled by default, since the input field is blank
+    cy.get("input[type=submit]").should("be.disabled");
+
+    cy.get("input[type=text]").type("Auckland");
+    cy.get("input[type=submit]").should("not.be.disabled");
+
+    cy.get("input[type=text]").type("ddddddd");
+    cy.get("input[type=submit]").should("be.disabled");
+  });
+});

--- a/cypress/e2e/capidle/navigation.cy.js
+++ b/cypress/e2e/capidle/navigation.cy.js
@@ -18,7 +18,7 @@ describe("capidle navigation", () => {
     cy.get("main .guess").should("have.length", 0);
 
     // type in a guess
-    cy.get("input[type=text]").type("Adelaide");
+    cy.get("input[type=text]").type("Lower Hutt");
     cy.get("input[type=submit]").click();
 
     // input was cleared
@@ -28,7 +28,9 @@ describe("capidle navigation", () => {
     cy.get("main .guess").should("have.length", 1);
 
     // the only hint row is correctly populated
-    cy.get("main .guess > span:first-child()").should("have.text", "Adelaide");
+
+    // prettier-ignore
+    cy.get("main .guess > span:first-child()").should("have.text", "Lower Hutt");
     cy.get("main .guess > span:nth-child(2)").should("have.text", "1,200km");
     cy.get("main .guess > span:last-child()").should("have.text", "↗️");
 
@@ -43,7 +45,7 @@ describe("capidle navigation", () => {
     cy.get("main .guess").should("have.length", 5);
 
     // make the final guess
-    cy.get("input[type=text]").type("Ouagadougou");
+    cy.get("input[type=text]").type("Upper Hutt");
     cy.get("input[type=submit]").click();
 
     // the game UI has been replaced by the results page

--- a/src/capidle/capidle.css
+++ b/src/capidle/capidle.css
@@ -11,6 +11,7 @@ body {
     "nav nav nav nav" auto
     "map . main ." 1fr /
     50% 1fr auto 1fr;
+  overflow: hidden;
 }
 @media only screen and (max-width: 700px) {
   body {
@@ -34,8 +35,7 @@ body {
 
 main {
   grid-area: main;
-  background-color: #0f0;
-  max-width: 300px;
+  max-width: 400px;
   margin: 16px;
 }
 
@@ -47,11 +47,57 @@ main {
 .empty-guess,
 .guess {
   height: 20px;
-  background: #aaa;
-  margin: 4px;
+  background: #ccc;
+  margin: 4px 0;
   border-radius: 4px;
+  padding: 12px;
 }
 
 core-navbar {
   grid-area: nav;
+}
+
+form {
+  display: flex;
+}
+form input {
+  padding: 12px;
+  font-size: 20px;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+form input[type="text"] {
+  margin-right: 2px;
+}
+
+/* the autofill popup */
+.autofill-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.autofill-popup {
+  border: 1px solid #ddd;
+  border-bottom: none;
+  border-top: none;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  z-index: 5;
+}
+
+.autofill-popup div {
+  background-color: white;
+  padding: 10px;
+  cursor: pointer;
+  border-bottom: 1px solid #ddd;
+}
+
+.autofill-popup div:hover {
+  background-color: #eee;
+}
+
+.autofill-popup div.active {
+  background-color: var(--theme) !important;
+  color: white;
 }

--- a/src/capidle/index.html
+++ b/src/capidle/index.html
@@ -29,8 +29,8 @@
 
         If your guess is wrong, you will be given a hint:
       </p>
-      <div class="modal-text">
-        <div class="guess-rows" style="max-width: 300px">
+      <div class="modal-text" style="display: flex; justify-content: center">
+        <div class="guess-rows" style="width: 300px">
           <div class="guess">
             <span>Berlin</span>
             <span>1,200km</span>
@@ -48,14 +48,12 @@
 
     <main>
       <div id="guess-rows" class="guess-rows"></div>
-      <div>
-        <input
-          type="text"
-          autocomplete="off"
-          placeholder="Enter your guess..."
-        />
-        <input type="submit" value="Guess" />
-      </div>
+      <form>
+        <div class="autofill-wrapper">
+          <input type="text" autofill="off" placeholder="Enter your guess..." />
+        </div>
+        <input type="submit" value="Guess" disabled />
+      </form>
     </main>
 
     <script type="module" src="../main.js"></script>

--- a/src/capidle/script/autofill.js
+++ b/src/capidle/script/autofill.js
@@ -1,0 +1,86 @@
+import { normalizeString } from "./is-guess-correct";
+import { gameModes } from "./puzzle";
+import { $, GAME_MODE } from "./util";
+
+const autofillFinishEvent = new Event("input");
+
+let focussed = -1; // the index of the currently focussed list item, if any
+
+const input = $("input[type=text]");
+
+function closeAutofill() {
+  // reset the focus and delete all list items
+  focussed = -1;
+
+  document
+    .querySelectorAll(".autofill-popup")
+    .forEach((el) => el.parentNode.removeChild(el));
+}
+
+input.addEventListener("input", (e) => {
+  if (e === autofillFinishEvent) return; // abort because this would create an infinite cycle
+
+  closeAutofill();
+  const userInput = normalizeString(e.target.value.trim());
+  if (!userInput) return;
+
+  // destroy and recreate the popup when ever the user types
+  const popup = document.createElement("div");
+  popup.setAttribute("class", "autofill-popup");
+
+  const filteredOptions = gameModes[GAME_MODE].db
+    .filter((city) =>
+      // check if the user input matches the city's name in any language
+      Object.values(city.names).some((name) =>
+        normalizeString(name).includes(userInput)
+      )
+    )
+    .slice(0, 50); // maxmium 50 items will be rendered for performance
+
+  // for every city that matches, add a row to the popup
+  for (const city of filteredOptions) {
+    const item = document.createElement("div");
+    item.dataset.val = city.names.en;
+    item.innerHTML = city.names.en;
+    item.addEventListener("click", () => {
+      input.value = item.dataset.val;
+      input.dispatchEvent(autofillFinishEvent);
+      closeAutofill();
+    });
+    popup.appendChild(item);
+  }
+
+  input.parentNode.appendChild(popup);
+});
+
+input.addEventListener("keydown", (e) => {
+  const allItems = input.parentElement.querySelectorAll(
+    ".autofill-popup > div"
+  );
+
+  if (e.key == "ArrowDown" || e.key == "ArrowUp") {
+    const offset = e.key == "ArrowDown" ? +1 : -1;
+
+    // increase the focussed index by +1 or -1.
+    // Math.min/max prevents the index from exceding the limits
+    focussed = Math.max(Math.min(focussed + offset, allItems.length - 1), 0);
+
+    // remove the active class from all items, and then add it back to the new focussed item
+    for (const element of allItems) element.classList.remove("active");
+    allItems[focussed].classList.add("active");
+
+    return;
+  }
+
+  if (e.key == "Enter") {
+    // if the popup is open, then enter should close the popup
+    // otherwise, enter should submit the form
+    if ($(".autofill-popup")) {
+      e.preventDefault(); // so that enter doesn't trigger the form's submit button
+      allItems[focussed]?.click();
+    }
+  }
+});
+
+// destroy the popup if the user clicks anywhere else
+document.addEventListener("click", closeAutofill);

--- a/src/capidle/script/index.js
+++ b/src/capidle/script/index.js
@@ -1,11 +1,27 @@
 import { guesses, render } from "./render";
-import { $ } from "./util";
+import { $, GAME_MODE } from "./util";
+import { isGuessCorrect } from "./is-guess-correct";
+import { gameModes } from "./puzzle";
+import "./autofill";
+
+function findMatch(input) {
+  // find the first city that matches the user input
+  return gameModes[GAME_MODE].db.find((city) => isGuessCorrect(city, input));
+}
 
 /* register event listeners */
 
+// when the user types
+$("input[type=text]").addEventListener("input", (e) => {
+  // disable the submit button if the current input matches no cities
+  $("input[type=submit]").disabled = !findMatch(e.target.value);
+});
+
 // when the submit button is clicked
-$("input[type=submit]").addEventListener("click", () => {
-  const guess = $("input[type=text]").value.trim();
+$("form").addEventListener("submit", (e) => {
+  e.preventDefault();
+
+  const guess = findMatch($("input[type=text]").value);
   if (!guess) return; // input field is blank, abort
 
   guesses.push(guess);

--- a/src/capidle/script/is-guess-correct.js
+++ b/src/capidle/script/is-guess-correct.js
@@ -3,7 +3,7 @@
  * and removes special characters like macrons.
  * @param {string} guess
  */
-const normalizeString = (guess) =>
+export const normalizeString = (guess) =>
   guess
     .trim()
     .toLowerCase()

--- a/src/capidle/script/puzzle.js
+++ b/src/capidle/script/puzzle.js
@@ -27,7 +27,12 @@ export function generatePuzzle(gameMode) {
   // if the URL contains `?test`, the puzzle is always the same, to allow for automated tests
   if (location.search.includes("?test")) return db[22];
 
-  return db[Math.floor(Math.random() * db.length)];
+  const puzzle = db[Math.floor(Math.random() * db.length)];
+
+  // print the answer to the devtools console to assist debugging
+  console.log(`SPOILER: The answer is ${puzzle.names.en}`);
+
+  return puzzle;
 }
 
 /** @typedef {ReturnType<typeof generatePuzzle>} Answer */

--- a/src/capidle/script/render.js
+++ b/src/capidle/script/render.js
@@ -1,13 +1,10 @@
-import { isGuessCorrect } from "./is-guess-correct";
 import { gameModes, generatePuzzle } from "./puzzle";
-import { $, NUMBER_OF_GUESSES } from "./util";
-
-const GAME_MODE = "nzCities";
+import { $, GAME_MODE, NUMBER_OF_GUESSES } from "./util";
 
 /** @type {L.Map} */
 let map;
 
-/** @type {string[]} the list of gusses that the user has made */
+/** @type {import("./puzzle").Answer[]} the list of gusses that the user has made */
 export let guesses = [];
 
 /** @type {import("./puzzle").Answer} the correct answer */
@@ -23,7 +20,7 @@ export function render() {
 
   // check if the user's most recent guess was correct
   const prevGuess = guesses.slice(-1)[0];
-  const prevGuessWasCorrect = isGuessCorrect(answer, prevGuess);
+  const prevGuessWasCorrect = answer.names.en === prevGuess?.names.en;
   if (prevGuessWasCorrect) return renderResultsUi(/* successful */ true);
 
   // check if the user has run out of guesses
@@ -47,7 +44,7 @@ function renderGameUi() {
       return guess
         ? `
             <div class="guess">
-              <span>${guess}</span>
+              <span>${guess.names.en}</span>
               <span>${hintDistance}</span>
               <span>${hintDirection}</span>
             </div>
@@ -75,7 +72,7 @@ function renderGameUi() {
   if (!layer) {
     // there's no tile layer configured, so we add one
     L.tileLayer(gameMode.tileServer, {
-      // minZoom: 12, // TODO: this could be a "hard mode"
+      // minZoom: 12, // this could be a "hard mode"
       maxZoom: 19,
       attribution: gameMode.attribution,
     }).addTo(map);

--- a/src/capidle/script/util.js
+++ b/src/capidle/script/util.js
@@ -1,6 +1,7 @@
 // this file contains helper functions and constants
 
 export const NUMBER_OF_GUESSES = 6;
+export const GAME_MODE = "nzCities";
 
 /** shortcut for document.querySelector */
 export const $ = (id) => document.querySelector(id);


### PR DESCRIPTION
This PR creates an autofill/autocomplete popup, which appears above the text input in the Capidle mini game. It shows suggestions based on what you type, and lets you search in any language. 

Having this feature means we can disable the submit button if the user has typed an invalid guess. 

**To test:** open Capidle, and type something into the text input. Use the arrow keys/enter to navigate through the list, or use the mouse.