### PR TITLE
Hide help modal once seen

### DIFF
--- a/src/components/script/help-modal.js
+++ b/src/components/script/help-modal.js
@@ -45,7 +45,7 @@ class Modal extends HTMLElement {
       if (event.target == modal) closeModal();
     };
 
-    // hide the help modal by defalut
+    // hide the help modal by default
     modal.style.display = "none";
 
     // if user havent seen the modal, show the modal once the window is open

--- a/src/components/script/help-modal.js
+++ b/src/components/script/help-modal.js
@@ -29,6 +29,7 @@ class Modal extends HTMLElement {
     function closeModal() {
       modal.style.display = "none";
       document.removeEventListener("keydown", onKeyDownInModal);
+      localStorage["seen-modal-" + location] = true;
     }
 
     function openModal() {
@@ -44,8 +45,6 @@ class Modal extends HTMLElement {
       if (event.target == modal) closeModal();
     };
 
-    // open the window by default
-    openModal();
   }
 }
 

--- a/src/components/script/help-modal.js
+++ b/src/components/script/help-modal.js
@@ -45,6 +45,11 @@ class Modal extends HTMLElement {
       if (event.target == modal) closeModal();
     };
 
+    // hide the help modal by defalut
+    modal.style.display = "none";
+
+    // if user havent seen the modal, show the modal once the window is open
+    if (!localStorage["seen-modal-" + location]) openModal();
   }
 }
 


### PR DESCRIPTION
## Motivation
Not displaying the modal when opening the game once it is seen.

## Summary of changes
record if the help modal is seen in local storage, check if it is seen before opening the game

## Attached GitHub issue
closes #98