### PR TITLE
fix: fixed a bug where users can enter values while the help modal is present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
       # if tests pass and we're on the mainline branch (and not in a forked repo), then deploy the client to the website
       - name: 🚀 Deploy
-        if: ${{ github.repository == 'se310-Team4/KKDZ' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'se310-Team4/KKDZ' && github.event_name == 'push' && github.ref == 'refs/heads/release-1.0' }}
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/cypress/e2e/liedle/start.cy.js
+++ b/cypress/e2e/liedle/start.cy.js
@@ -14,6 +14,30 @@ describe("initialise grid", () => {
   });
 });
 
+describe("can't type while help modal present", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:1234/liedle/index.html");
+  });
+
+  it("test can't type while help modal present", () => {
+    cy.get("body").type("s");
+    cy.get(`[data-col-index=0][data-row-index=0].tile`).first().should("have.text", "");
+  });
+
+  it("test can type after help modal closed", () => {
+    cy.get("[id=close-btn]").click();
+    cy.get("body").type("s");
+    cy.get(`[data-col-index=0][data-row-index=0].tile`).first().should("have.text", "S");
+  });
+
+  it("test can't type after modal reopened", () => {
+    cy.get("[id=close-btn]").click();
+    cy.get("[id=help-btn]").click();
+    cy.get("body").type("s");
+    cy.get(`[data-col-index=0][data-row-index=0].tile`).first().should("have.text", "");
+  });
+});
+
 describe("end game components", () => {
   beforeEach(() => {
     cy.visit("http://localhost:1234/liedle/index.html");

--- a/src/components/script/help-modal.js
+++ b/src/components/script/help-modal.js
@@ -30,11 +30,13 @@ class Modal extends HTMLElement {
       modal.style.display = "none";
       document.removeEventListener("keydown", onKeyDownInModal);
       localStorage["seen-modal-" + location] = true;
+      document.dispatchEvent(new Event("modal-closed"));
     }
 
     function openModal() {
       modal.style.display = "block";
       document.addEventListener("keydown", onKeyDownInModal);
+      document.dispatchEvent(new Event("modal-opened"));
     }
 
     closeBtn.onclick = closeModal;

--- a/src/liedle/index.js
+++ b/src/liedle/index.js
@@ -19,7 +19,9 @@ function start() {
   isEndGame = false;
   createGrid();
   resetGame();
-  handleInput();
+
+  document.addEventListener("modal-closed", handleInput);
+  document.addEventListener("modal-opened", disableInput);
 }
 
 function resetGame() {
@@ -84,22 +86,30 @@ function pickSecretWord() {
 }
 
 // handles key presses from the user
-function handleInput() {
-  document.addEventListener("keydown", function onEvent(e) {
-    if (isEndGame) {
-      return;
-    }
+function onKeyDownInGame(e) {
+  if (isEndGame) {
+    return;
+  }
 
-    const key = e.key;
-    // regex matches any lowercase or uppercase english letter
-    if (key.length === 1 && e.key.match(/^[a-z]/i)) {
-      handleLetter(key);
-    } else if (e.key === "Enter") {
-      handleEnter();
-    } else if (e.key === "Backspace") {
-      handleBackspace();
-    }
-  });
+  const key = e.key;
+  // regex matches any lowercase or uppercase english letter
+  if (key.length === 1 && e.key.match(/^[a-z]/i)) {
+    handleLetter(key);
+  } else if (e.key === "Enter") {
+    handleEnter();
+  } else if (e.key === "Backspace") {
+    handleBackspace();
+  }
+}
+
+// enable the handling of key presses
+function handleInput() {
+  document.addEventListener("keydown", onKeyDownInGame);
+}
+
+// disable the handling of key presses
+function disableInput() {
+  document.removeEventListener("keydown", onKeyDownInGame);
 }
 
 // add the letter to the grid if possible


### PR DESCRIPTION
## Todo
- [x] add test to validate failure condition
- [x] fix bug by adding event emits from the help modal when opened/closed 

## Motivation

Users should not be able to enter text into the game while the help modal is present. They could accidentally use up guesses, and it would be frustrating.

## Summary of changes

- Help modal in `components/script/help-modal.js` now emits `modal-open` and `modal-close` events at the `document` scope.
- Tests added to validate that text may only be entered while the modal is closed.
- `liedle/index.js` keystroke input respects whether or not the modal is open to allow the user to enter keys.

## Attached GitHub issue

Closes #81

## Checklist

### Local Build
- [x] Ran all local tests `npm run test:ci`
- [x] Manually tested my solution

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR