### PR TITLE
fix: fixed a bug in that words with multiple identical letters would be marked as only partially-correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist
 # not used by this project
 cypress/fixtures
 cypress/videos
+cypress/screenshots/*

--- a/cypress/e2e/liedle/colour-letter.cy.js
+++ b/cypress/e2e/liedle/colour-letter.cy.js
@@ -44,3 +44,24 @@ describe("game has a chance of incorrectly colouring each letter", () => {
     cy.get(`[data-col-index=2][data-row-index=0].tile`).first().should("not.have.attr", "data-type", "right");
   });
 });
+
+describe("game will correctly color words with multiple letters of the same type", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:1234/liedle/index.html");
+    cy.get("[id=close-btn]").click();
+    // override global variables for testing purposes
+    cy.window().then((win) => {
+      win.secretWord = "hello";
+      win.lieRate = 0.0;
+    });
+    cy.get("body").type("hello").type("{enter}");
+  });
+
+  it("test right letter right place", () => {
+    cy.get(`[data-col-index=0][data-row-index=0].tile`).first().should("have.attr", "data-type", "right");
+    cy.get(`[data-col-index=1][data-row-index=0].tile`).first().should("have.attr", "data-type", "right");
+    cy.get(`[data-col-index=2][data-row-index=0].tile`).first().should("have.attr", "data-type", "right");
+    cy.get(`[data-col-index=3][data-row-index=0].tile`).first().should("have.attr", "data-type", "right");
+    cy.get(`[data-col-index=4][data-row-index=0].tile`).first().should("have.attr", "data-type", "right");
+  });
+});

--- a/src/liedle/index.js
+++ b/src/liedle/index.js
@@ -156,37 +156,27 @@ function colourWord(word) {
 }
 
 function colourLetter(tile) {
-  let index = window.secretWord.indexOf(tile.innerHTML.toLowerCase());
-  switch (index) {
-    case -1:
-      tile.dataset.type = "wrong";
-      break;
-    case parseInt(tile.dataset.colIndex):
-      tile.dataset.type = "right";
-      break;
-    default:
-      tile.dataset.type = "right-letter";
-      break;
+  let testChar = tile.innerHTML.toLowerCase();
+  if (secretWord.charAt(tile.dataset.colIndex) === testChar) {
+    tile.dataset.type = "right";
+  } else if (secretWord.includes(testChar)) {
+    tile.dataset.type = "right-letter";
+  } else {
+    tile.dataset.type = "wrong";
   }
 }
 
 function colourLetterFalsely(tile) {
-  let type;
-  let index = window.secretWord.indexOf(tile.innerHTML.toLowerCase());
-  // set the type to one of the incorrect types
-  switch (index) {
-    case -1:
-      type = Math.random() < 0.5 ? "right" : "right-letter";
-      break;
-    case parseInt(tile.dataset.colIndex):
-      type = Math.random() < 0.5 ? "wrong" : "right-letter";
-      break;
-    default:
-      type = Math.random() < 0.5 ? "right" : "wrong";
-      break;
+  let testChar = tile.innerHTML.toLowerCase();
+  if (secretWord.charAt(tile.dataset.colIndex) === testChar) {
+    tile.dataset.type =  Math.random() < 0.5 ? "wrong" : "right-letter";
+  } else if (secretWord.includes(testChar)) {
+    tile.dataset.type = Math.random() < 0.5 ? "right" : "wrong";;
+  } else {
+    tile.dataset.type = Math.random() < 0.5 ? "right" : "right-letter";
   }
-  tile.dataset.type = type;
 }
+
 
 function checkEndGame(word) {
   if (word === window.secretWord) {


### PR DESCRIPTION
## Todo
- [x] add test to validate failure condition
- [x] fix bug by updating the `colourLetter()` and `colourLetterFalsely()` functions

## Motivation

Liedle incorrectly colours tiles for words with repeated letters. More specifically, only the first occurrence of the repeated letters is coloured correctly, the rest are coloured yellow.

## Summary of changes

- Tests added to validate that when entering a word like `hello` all letters are marked as green for correct
- `liedle/index.js` updated function to check the char at the correct index, instead of getting the first occurrence

## Attached GitHub issue

Closes #90 

## Checklist

### Local Build
- [x] Ran all local tests `npm run test:ci`
- [x] Manually tested my solution

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR