### PR TITLE
Check mergeable tiles in check lose

### DIFF
--- a/cypress/e2e/2048-expert/end-game.cy.js
+++ b/cypress/e2e/2048-expert/end-game.cy.js
@@ -8,12 +8,10 @@ describe("end game triggers", () => {
   });
 
   it("test lost", () => {
-    // fill up the board with tiles that leave the user with no more moves
+    // fill up the board with tiles and they are not mergeable
     for (let i = 0; i < TOTAL_CELL; i++) {
       if (i % 2) {
-        cy.get(".cell").eq(i).invoke("text", 2);
-      } else {
-        cy.get(".cell").eq(i).invoke("text", 4);
+        cy.get(".cell").eq(i).invoke("text", i);
       }
     }
 
@@ -22,6 +20,19 @@ describe("end game triggers", () => {
     cy.on("window:alert", (t) => {
       expect(t).to.contains("\t\t You Lost\n Your score is ");
     });
+  });
+
+  it("board filled but mergeable", () =>{
+    // fill up the board with tiles but tiles are mergeable
+    for (let i = 0; i < TOTAL_CELL; i++) {
+      if (i % 2) {
+        cy.get(".cell").eq(i).invoke("text", 2);
+      } else {
+        cy.get(".cell").eq(i).invoke("text", 4);
+      }
+    }
+
+    cy.get(".cell").contains("2").invoke("data", "index").should("be.gt", -1);
   });
 
   it("test win", () => {

--- a/cypress/e2e/2048-expert/end-game.cy.js
+++ b/cypress/e2e/2048-expert/end-game.cy.js
@@ -24,6 +24,7 @@ describe("end game triggers", () => {
 
   it("board filled but mergeable", () =>{
     // fill up the board with tiles but tiles are mergeable
+    let spy = cy.spy(window, 'alert');
     for (let i = 0; i < TOTAL_CELL; i++) {
       if (i % 2) {
         cy.get(".cell").eq(i).invoke("text", 2);
@@ -32,7 +33,8 @@ describe("end game triggers", () => {
       }
     }
 
-    cy.get(".cell").contains("2").invoke("data", "index").should("be.gt", -1);
+    expect(spy).to.haveOwnProperty('callCount');
+    expect(spy).to.not.be.called;
   });
 
   it("test win", () => {

--- a/src/2048-expert/index.js
+++ b/src/2048-expert/index.js
@@ -234,10 +234,10 @@ function checkLost() {
   if (numEmptyCells == 0) {
     // check if any tiles are mergeable
       for (let i = 0; i < totalCell; i++) {
-      // check horizontal 
-      if((cells[i].innerHTML != cells[i+1].innerHTML)&& i%6 != 0){
-        // check vertical
-        if((cells[i].innerHTML != cells[i+6].innerHTML)){
+      // check vertical
+      if((cells[i].innerHTML != cells[i+6].innerHTML)){
+        // check horizontal 
+        if((cells[i].innerHTML != cells[i+1].innerHTML) && i%6 != 0){
           alert("\t\t You Lost\n Your score is " + currentScore);
           newGame();
         }

--- a/src/2048-expert/index.js
+++ b/src/2048-expert/index.js
@@ -1,5 +1,3 @@
-const { floor } = require("cypress/types/lodash");
-
 const gameBoard = document.querySelector(".game-board");
 const currentScoreDisplay = document.getElementById("current-score");
 const bestScoreDisplay = document.getElementById("best-score");
@@ -33,7 +31,6 @@ function generateNewTile() {
     if(!checkisFull()){
       generateNewTile();
     }
-    
   }
 }
 
@@ -192,6 +189,7 @@ function keyUpLeft() {
   moveLeft();
   generateTwoNewTile();
   addColours();
+  checkLost();
 }
 
 function keyUpRight() {
@@ -200,6 +198,7 @@ function keyUpRight() {
   moveRight();
   generateTwoNewTile();
   addColours();
+  checkLost();
 }
 
 function keyUpUp() {
@@ -208,6 +207,7 @@ function keyUpUp() {
   moveUp();
   generateTwoNewTile();
   addColours();
+  checkLost();
 }
 
 function keyUpDown() {
@@ -216,6 +216,7 @@ function keyUpDown() {
   moveDown();
   generateTwoNewTile();
   addColours();
+  checkLost();
 }
 
 // a win happens when 2048 is generated
@@ -230,7 +231,6 @@ function checkWin() {
 
 // a loss happens when all cells are full and they are not mergeable 
 function checkLost() {
-  
   if (checkisFull()) {
     // check if any tiles are mergeable
     for (let i = 0; i < totalCell-6; i++) {
@@ -243,7 +243,7 @@ function checkLost() {
     for (let i = 0; i < totalCell-1; i++) {
       if((cells[i].innerHTML == cells[i+1].innerHTML) && i%6 != 0){
          // the user did not lose the game
-          return;
+        return;
       }
     }
     alert("\t\t You Lost\n Your score is " + currentScore);
@@ -260,9 +260,7 @@ function checkisFull(){
     }
   }
 
-  if (numEmptyCells == 0){
-    return true;
-  }
+  return numEmptyCells == 0;
 }
 
 // function start new game

--- a/src/2048-expert/index.js
+++ b/src/2048-expert/index.js
@@ -232,8 +232,17 @@ function checkLost() {
     }
   }
   if (numEmptyCells == 0) {
-    alert("\t\t You Lost\n Your score is " + currentScore);
-    newGame();
+    // check if any tiles are mergeable
+      for (let i = 0; i < totalCell; i++) {
+      // check horizontal 
+      if((cells[i].innerHTML != cells[i+1].innerHTML)&& i%6 != 0){
+        // check vertical
+        if((cells[i].innerHTML != cells[i+6].innerHTML)){
+          alert("\t\t You Lost\n Your score is " + currentScore);
+          newGame();
+        }
+      }
+    }
   }
 }
 

--- a/src/2048-expert/index.js
+++ b/src/2048-expert/index.js
@@ -1,3 +1,5 @@
+const { floor } = require("cypress/types/lodash");
+
 const gameBoard = document.querySelector(".game-board");
 const currentScoreDisplay = document.getElementById("current-score");
 const bestScoreDisplay = document.getElementById("best-score");
@@ -28,7 +30,10 @@ function generateNewTile() {
   } else {
     // if a cell is already has a number, then find a new tile
     checkLost();
-    generateNewTile();
+    if(!checkisFull()){
+      generateNewTile();
+    }
+    
   }
 }
 
@@ -223,26 +228,40 @@ function checkWin() {
   }
 }
 
-// a loss happens when all cells are full
+// a loss happens when all cells are full and they are not mergeable 
 function checkLost() {
+  
+  if (checkisFull()) {
+    // check if any tiles are mergeable
+    for (let i = 0; i < totalCell-6; i++) {
+      // check vertical
+      if((cells[i].innerHTML == cells[i+6].innerHTML)){
+        // the user did not lose the game
+        return;
+      }
+    }
+    for (let i = 0; i < totalCell-1; i++) {
+      if((cells[i].innerHTML == cells[i+1].innerHTML) && i%6 != 0){
+         // the user did not lose the game
+          return;
+      }
+    }
+    alert("\t\t You Lost\n Your score is " + currentScore);
+    newGame();
+  }
+}
+
+// check if the board is full
+function checkisFull(){
   let numEmptyCells = 0;
   for (let i = 0; i < totalCell; i++) {
     if (cells[i].innerHTML == 0) {
       numEmptyCells++;
     }
   }
-  if (numEmptyCells == 0) {
-    // check if any tiles are mergeable
-      for (let i = 0; i < totalCell; i++) {
-      // check vertical
-      if((cells[i].innerHTML != cells[i+6].innerHTML)){
-        // check horizontal 
-        if((cells[i].innerHTML != cells[i+1].innerHTML) && i%6 != 0){
-          alert("\t\t You Lost\n Your score is " + currentScore);
-          newGame();
-        }
-      }
-    }
+
+  if (numEmptyCells == 0){
+    return true;
   }
 }
 


### PR DESCRIPTION
## Todo
- [x] add test to validate failure condition
- [x] fix bug by adding check conditions on checkLost() function

## Motivation

Players should continue the game even if the board is filled but merging is possible. Once the tiles are merged, we created more space for new tiles to generate

## Summary of changes

- Tests were added to check if the game still stops when the board is full but merging is possible 
- `2048expert/index.js` adding checking conditions on checklost function for detecting mergeable tiles

## Attached GitHub issue

Closes #99

## Checklist

### Local Build
- [x] Ran all local tests `npm run test:ci`
- [x] Manually tested my solution

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR