### PR TITLE
fix: fixed 2048 tile not being generated on win condition on some browsers

### DIFF
--- a/cypress/e2e/2048-expert/end-game.cy.js
+++ b/cypress/e2e/2048-expert/end-game.cy.js
@@ -47,4 +47,17 @@ describe("end game triggers", () => {
       expect(t).to.contains("\t\t You win! \n Your score is ");
     });
   });
+
+  it("test 2048 shown", () => {
+    cy.get(".cell").eq(0).invoke("text", 1024);
+    cy.get(".cell").eq(1).invoke("text", 1024);
+
+    cy.get("body").trigger("keyup", { keyCode: 37 });
+
+    cy.on("window:alert", (t) => {
+      expect(t).to.contains("\t\t You win! \n Your score is ");
+    });
+
+    cy.get(".cell").contains("2048").should("have.attr", "data-digits", "4");
+  });
 });

--- a/src/2048-expert/index.js
+++ b/src/2048-expert/index.js
@@ -6,6 +6,7 @@ let totalCell = WIDTH * WIDTH;
 let cells = [];
 let currentScore = 0;
 let bestScore = getBestScore() === null ? 0 : getBestScore();
+let gameEnd = false;
 
 // create and add cells to the board
 function createBoard() {
@@ -22,6 +23,8 @@ function createBoard() {
 
 // generate number (2 or 4) at a random available cell
 function generateNewTile() {
+  if (gameEnd) return;
+
   const rand = Math.floor(Math.random() * cells.length);
   if (cells[rand].innerHTML == 0) {
     cells[rand].innerHTML = randomNumTwoOrFour();
@@ -172,6 +175,8 @@ function updateScores(bonus) {
 
 // bind user action with key
 function control(e) {
+  if (gameEnd) return;
+
   if (e.keyCode === 37) {
     keyUpLeft();
   } else if (e.keyCode === 38) {
@@ -223,8 +228,13 @@ function keyUpDown() {
 function checkWin() {
   for (let i = 0; i < totalCell; i++) {
     if (cells[i].innerHTML == 2048) {
-      alert("\t\t You win! \n Your score is " + currentScore);
-      newGame();
+      gameEnd = true;
+      // HACK: Some browsers update the DOM asynchronously but only after the current call stack has cleared.
+      // by creating a 1ms delay, we allow the browser to asynchronously update the DOM and then display the
+      // alert effectively instantly.
+      // See: https://stackoverflow.com/questions/38960101/why-is-element-not-being-shown-before-alert
+      // Note: issue does not appear on firefox, only on chromium-based browsers
+      setTimeout(() => alert("\t\t You win! \n Your score is " + currentScore), 1);
     }
   }
 }
@@ -246,8 +256,15 @@ function checkLost() {
         return;
       }
     }
-    alert("\t\t You Lost\n Your score is " + currentScore);
-    newGame();
+    if (numEmptyCells == 0) {
+      gameEnd = true;
+        // HACK: Some browsers update the DOM asynchronously but only after the current call stack has cleared.
+        // by creating a 1ms delay, we allow the browser to asynchronously update the DOM and then display the
+        // alert effectively instantly.
+        // See: https://stackoverflow.com/questions/38960101/why-is-element-not-being-shown-before-alert
+        // Note: issue does not appear on firefox, only on chromium-based browsers
+      setTimeout(() => alert("\t\t You Lost\n Your score is " + currentScore), 1);
+    }
   }
 }
 
@@ -351,5 +368,6 @@ document.addEventListener("keyup", control);
 // allow restarting the game
 const newBtn = document.getElementById("new-btn");
 newBtn.onclick = function () {
+  gameEnd = false;
   newGame();
 };


### PR DESCRIPTION
## Todo
- [x] add test to validate failure condition
- [x] implement fix for the failure condition
- [x] ensure fix works on all browsers

## Motivation

Expert-2048 sometimes didn't properly show the 2048 square on some browsers at the end of the game.

## Summary of changes

- Tests added to validate that when entering a word like `hello` all letters are marked as green for correct
- Game no longer resets after user clicks ok, related to below.
- Game was not properly disabled after win or failure condition, implementation of the new tile system is recursive. On failure condition, game would infinitely attempt to spawn new tiles with no exit condition - resulting in a stack overflow. Addressing this recursive implementation would be ideal, as some preliminary testing shows that the function runs 150-200 times in some cases to generate valid tiles - which is excessive. Calls to `checkLost` mean this function takes 1-2ms to run, which on a modern browser is excessive.

## Attached GitHub issue

Closes #94 

## Checklist

### Local Build
- [x] Ran all local tests `npm run test:ci`
- [x] Manually tested my solution

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR