### PR TITLE
Home page responsiveness

### DIFF
--- a/src/brain-gain/index.js
+++ b/src/brain-gain/index.js
@@ -19,3 +19,5 @@ function titleShow() {
   document.getElementById("liedle-details").style.opacity = "0%";
   document.getElementById("a2048expert-details").style.opacity = "0%";
 }
+
+

--- a/src/brain-gain/main.css
+++ b/src/brain-gain/main.css
@@ -91,8 +91,6 @@ core-navbar > div {
   text-align: center;
   text-decoration: none;
   z-index: 2;
-  /* width: 20%;
-  height: 35%; */
   width: 380px;
   height: 320px; 
   display: flex;
@@ -111,18 +109,12 @@ core-navbar > div {
 
 .title-img {
   display: block;
-  /* margin-left: auto;
-  margin-right: auto;*/
   margin-top: 4%; 
   transition: 0.6s;
   height: 340px;
 }
 
 .game-details {
-  /* position: absolute; */
-  /* left: 10%; */
-  /* top: 15%; */
-  /* opacity: 0%; */
   transition: 0.6s;
   transition: opacity 0.6s ease-out;
   
@@ -146,41 +138,18 @@ core-navbar > div {
 }
 
 .game-details-title {
-  /* width: 40%; */
   color: #595959;
   font-size: 28px;
   font-weight: bold;
 }
 
 .game-details-text {
-  /* width: 40%; */
   color: #595959;
   font-size: 22px;
 }
 
 .game-details-img {
-  /* position: absolute; */
-  /* left: 60%;
-  top: 5%;*/
   height: 345px;
-}
-
-#capidle-btn {
-  /* position: absolute; */
-  /* left: 10%;
-  bottom: 5%; */
-}
-
-#liedle-btn {
-  /* position: absolute; */
-  /* left: 40%;
-  bottom: 5%; */
-}
-
-#a2048expert-btn {
-  /* position: absolute; */
-  /* left: 70%;
-  bottom: 5%; */
 }
 
 /* the modal window used in all mini games */

--- a/src/brain-gain/main.css
+++ b/src/brain-gain/main.css
@@ -261,7 +261,7 @@ core-navbar > div {
   }
 
   .game-details-img {
-    height: auto;
+    height: 180px;
   }
 
   .btn-container {

--- a/src/brain-gain/main.css
+++ b/src/brain-gain/main.css
@@ -261,7 +261,7 @@ core-navbar > div {
   }
 
   .game-details-img {
-    height: 180px;
+    height: auto;
   }
 
   .btn-container {

--- a/src/brain-gain/main.css
+++ b/src/brain-gain/main.css
@@ -20,6 +20,7 @@ core-navbar {
   display: flex;
   justify-content: space-between;
   font-size: x-large;
+  height: 45px;
 }
 core-navbar a {
   color: #fff;
@@ -49,6 +50,32 @@ core-navbar > div {
   color: #d82d46;
 }
 
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(100vh - 45px);
+  max-height: 200vh;
+}
+
+#center-info {
+  display:flex;
+  justify-content: center;
+  align-items: center;
+
+  height: 52%;
+  position: relative;
+}
+
+.btn-container {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+
+  height: 48%;
+}
+
+
 .games-button {
   background-color: #ffffff;
   border-radius: 20px;
@@ -64,8 +91,12 @@ core-navbar > div {
   text-align: center;
   text-decoration: none;
   z-index: 2;
-  width: 20%;
-  height: 35%;
+  /* width: 20%;
+  height: 35%; */
+  width: 380px;
+  height: 320px; 
+  display: flex;
+  flex-direction: column;
 }
 
 .games-button:hover {
@@ -80,57 +111,76 @@ core-navbar > div {
 
 .title-img {
   display: block;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 5%;
+  /* margin-left: auto;
+  margin-right: auto;*/
+  margin-top: 4%; 
   transition: 0.6s;
-  width: 35%;
+  height: 340px;
 }
 
 .game-details {
-  position: absolute;
-  left: 10%;
-  top: 15%;
-  opacity: 0%;
+  /* position: absolute; */
+  /* left: 10%; */
+  /* top: 15%; */
+  /* opacity: 0%; */
   transition: 0.6s;
+  transition: opacity 0.6s ease-out;
+  
+  width: 80%;
+  height: 100%;
+
+  position: absolute;
+  top: 0;
+  left: 10%;
+  margin-top: 2%;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0%;
+}
+
+.game-details div {
+  width: 50%;
+  height: 345px;
 }
 
 .game-details-title {
-  width: 40%;
+  /* width: 40%; */
   color: #595959;
   font-size: 28px;
   font-weight: bold;
 }
 
 .game-details-text {
-  width: 40%;
+  /* width: 40%; */
   color: #595959;
   font-size: 22px;
 }
 
 .game-details-img {
-  position: absolute;
-  left: 60%;
-  top: 5%;
-  width: 30%;
+  /* position: absolute; */
+  /* left: 60%;
+  top: 5%;*/
+  height: 345px;
 }
 
 #capidle-btn {
-  position: absolute;
-  left: 10%;
-  bottom: 5%;
+  /* position: absolute; */
+  /* left: 10%;
+  bottom: 5%; */
 }
 
 #liedle-btn {
-  position: absolute;
-  left: 40%;
-  bottom: 5%;
+  /* position: absolute; */
+  /* left: 40%;
+  bottom: 5%; */
 }
 
 #a2048expert-btn {
-  position: absolute;
-  left: 70%;
-  bottom: 5%;
+  /* position: absolute; */
+  /* left: 70%;
+  bottom: 5%; */
 }
 
 /* the modal window used in all mini games */
@@ -169,6 +219,71 @@ core-navbar > div {
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2), 0 6px 6px rgba(0, 0, 0, 0.2);
 }
 
+@media only screen and (max-width: 1200px) {
+  .game-details {
+    flex-direction: column;
+    row-gap: 30px;
+  }
+  .game-details div{
+    width: 100%;
+  }
+}
+
+@media only screen and (max-width: 700px) {
+  #center-info {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    height: 60%;
+  }
+
+  #title-img {
+    width: 80%;
+    height: auto;
+  }
+
+  .game-details {
+    font-size: 16px;
+    height: 80%;
+    left: 10%;
+    top: 10%;
+    width: 80%;
+    margin-top: 0;
+  }
+
+  .game-details-title {
+    font-size: 24px;
+  }
+  
+  .game-details-text {
+    font-size: 18px;
+  }
+
+  .game-details-img {
+    height: 180px;
+  }
+
+  .btn-container {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    row-gap: 10px;
+    width: 100%;
+  }
+
+  .games-button {
+    width: 90%;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .game-button-img {
+    width: 64px;
+  }
+}
+
 /* on small screens, the modal can be wider than normal */
 @media only screen and (max-width: 700px) {
   .modal-window {
@@ -202,3 +317,5 @@ core-navbar > div {
   text-decoration: none;
   cursor: pointer;
 }
+
+

--- a/src/index.html
+++ b/src/index.html
@@ -22,42 +22,51 @@
       <div>BrainGain</div>
     </core-navbar>
 
-    <div id="center-info">
-      <img id="title-img" src="./images/logo.png" alt="example" class="title-img" />
-      <div id="capidle-details" class="game-details">
-        <p class="game-details-title">Capidle</p>
-        <br>
-        <p class="game-details-text">This game is a blend between Wordle, flagle.io, and Geoguessr. An interactive map showing satellite imagery of a city will appear on your screen. Try to guess the city! But be careful, the map will not have any labels to help you out! How many tries will it take for you to figure out where exactly it is?</p>
-        <img src="./images/capidle-example.png" alt="Capidle example gameplay" class="game-details-img" />
+    <div class="content">
+      <div id="center-info">
+        <img id="title-img" src="./images/logo.png" alt="example" class="title-img" />
+        <div id="capidle-details" class="game-details">
+          <div>
+            <p class="game-details-title">Capidle</p>
+            <br>
+            <p class="game-details-text">This game is a blend between Wordle, flagle.io, and Geoguessr. An interactive map showing satellite imagery of a city will appear on your screen. Try to guess the city! But be careful, the map will not have any labels to help you out! How many tries will it take for you to figure out where exactly it is?</p>
+          </div>
+          <img src="./images/capidle-example.png" alt="Capidle example gameplay" class="game-details-img" />
+        </div>
+        <div id="liedle-details" class="game-details">
+          <div>
+            <p class="game-details-title">Liedle</p>
+            <br>
+            <p class="game-details-text">Liedle is a unique and more challenging variation of the popular word game, Wordle. The goal of the game is to guess the secret 5-letter word. After each guess, the color of the tiles will tell you more information about how close your guess was. But don't rely on the hints too much! The game will sometimes lie about the tile colour...</p>
+          </div>
+          <img src="./images/liedle-example.png" alt="Liedle example gameplay" class="game-details-img" />
+        </div>
+        <div id="a2048expert-details" class="game-details">
+          <div>
+            <p class="game-details-title">2048 Expert</p>
+            <br>
+            <p class="game-details-text">2048 Expert is a variation of 2048. But as the name implies, 2048 Expert is more of a challenge. Instead of 1 empty tile being added after every move, you will receive 2! How will another tile affect your merging skills? Have fun in a much larger 6 x 6 grid and try to make your way up to 2048.</p>
+          </div>
+          <img src="./images/a2048expert-example.png" alt="2048 Expert example gameplay" class="game-details-img" />
+        </div>
       </div>
-      <div id="liedle-details" class="game-details">
-        <p class="game-details-title">Liedle</p>
-        <br>
-        <p class="game-details-text">Liedle is a unique and more challenging variation of the popular word game, Wordle. The goal of the game is to guess the secret 5-letter word. After each guess, the color of the tiles will tell you more information about how close your guess was. But don't rely on the hints too much! The game will sometimes lie about the tile colour...</p>
-        <img src="./images/liedle-example.png" alt="Liedle example gameplay" class="game-details-img" />
-      </div>
-      <div id="a2048expert-details" class="game-details">
-        <p class="game-details-title">2048 Expert</p>
-        <br>
-        <p class="game-details-text">2048 Expert is a variation of 2048. But as the name implies, 2048 Expert is more of a challenge. Instead of 1 empty tile being added after every move, you will receive 2! How will another tile affect your merging skills? Have fun in a much larger 6 x 6 grid and try to make your way up to 2048.</p>
-        <img src="./images/a2048expert-example.png" alt="2048 Expert example gameplay" class="game-details-img" />
+
+      <!-- Buttons to the mini-games -->
+      <div class="btn-container">
+        <a id="capidle-btn" href="./capidle/index.html" class="games-button" onmouseenter="capidleDetails()" onmouseleave="titleShow()"><!---->
+          <img src="./images/capidle-logo.png" alt="Capidle logo" class="game-button-img" />
+          <p id="capidle-btn-text">Capidle</p>
+        </a>
+        <a id="liedle-btn" href="./liedle/index.html" class="games-button" onmouseenter="liedleDetails()" onmouseleave="titleShow()"><!--  -->
+          <img src="./images/liedle-logo.png" alt="Liedle logo" class="game-button-img" />
+          <p id="liedle-btn-text">Liedle</p>
+        </a>
+        <a id="a2048expert-btn" href="./2048-expert/index.html" class="games-button" onmouseenter="a2048ExpertDetails()" onmouseleave="titleShow()"><!--  -->
+          <img src="./images/a2048expert-logo.png" alt="2048 Expert logo" class="game-button-img" />
+          <p id="a2048expert-btn-text">2048 Expert</p>
+        </a>
       </div>
     </div>
-
-    <!-- Buttons to the mini-games -->
-    <a id="capidle-btn" href="./capidle/index.html" class="games-button" onmouseenter="capidleDetails()" onmouseleave="titleShow()">
-      <img src="./images/capidle-logo.png" alt="Capidle logo" class="game-button-img" />
-      <p id="capidle-btn-text">Capidle</p>
-    </a>
-    <a id="liedle-btn" href="./liedle/index.html" class="games-button" onmouseenter="liedleDetails()" onmouseleave="titleShow()">
-      <img src="./images/liedle-logo.png" alt="Liedle logo" class="game-button-img" />
-      <p id="liedle-btn-text">Liedle</p>
-    </a>
-    <a id="a2048expert-btn" href="./2048-expert/index.html" class="games-button" onmouseenter="a2048ExpertDetails()" onmouseleave="titleShow()">
-      <img src="./images/a2048expert-logo.png" alt="2048 Expert logo" class="game-button-img" />
-      <p id="a2048expert-btn-text">2048 Expert</p>
-    </a>
-
     <script type="module" src="./components/script/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Motivation

Descriptions of the games on the home page are blocked by the buttons in mobile view, hence, reducing the site's usability.

## Summary of changes

- grouped associated HTML elements in the `src/index.html` i.e. via the `content <div>` and the `btn-container <div>`
- added responsive behaviour (for mobile view) to those groupings - via the `src/brain-gain/main.css` - by increasing/decreasing the font and image sizes of the descriptions when the browser window's current width  is within a given range

![image](https://user-images.githubusercontent.com/79767691/192877572-542dcddc-807d-4f4c-9941-57422fb4b16c.png)


## Attached GitHub issue

Closes #114 

## Checklist

### Local Build
- [x] Ran all local tests `npm run test:ci`
- [x] Manually tested my solution

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR