### PR TITLE
2048 expert page responsiveness

### DIFF
--- a/src/2048-expert/2048-expert.css
+++ b/src/2048-expert/2048-expert.css
@@ -153,11 +153,31 @@ h1 {
     margin: 5px;
     border-radius: 3px;
     font-weight: bold;
-    font-size: 48px;
     background-color: #eee4da;
     color: #afa192;
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+    /* font size depends on number of digits in the tile  */
+  [data-digits="0"] {
+    color: rgb(175, 161, 132) !important; /* needed to override the font colour */
+  }
+
+  [data-digits="1"] {
+    font-size: 48px;
+  }
+
+  [data-digits="2"] {
+    font-size: 38px;
+  }
+
+  [data-digits="3"] {
+    font-size: 28px;
+  }
+
+  [data-digits="4"] {
+    font-size: 26px;
   }
 }

--- a/src/2048-expert/2048-expert.css
+++ b/src/2048-expert/2048-expert.css
@@ -25,6 +25,10 @@ h1 {
 .container {
   width: 600px;
   margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: rgba(255, 0, 0, 0.301);
 }
 
 .title {
@@ -120,4 +124,40 @@ h1 {
 
 [data-digits="4"] {
   font-size: 32px;
+}
+
+@media only screen and (max-width: 700px) {
+  .container {
+    width: 100%;
+  }
+
+  /* game board that contains the grid of tiles */
+  .game-board {
+    margin-top: 30px;
+    padding: 15px;
+    border-radius: 10px;
+    width: 444px;
+    height: 444px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    background-color: red;
+  }
+
+  /* cells on the game board */
+  .game-board div {
+    width: 64px;
+    height: 64px;
+    line-height: 80px;
+    margin: 5px;
+    border-radius: 3px;
+    font-weight: bold;
+    font-size: 48px;
+    background-color: #eee4da;
+    color: #afa192;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/src/2048-expert/2048-expert.css
+++ b/src/2048-expert/2048-expert.css
@@ -28,7 +28,6 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: rgba(255, 0, 0, 0.301);
 }
 
 .title {
@@ -60,6 +59,7 @@ h1 {
 .intro {
   font-size: 20px;
   line-height: 1.5;
+  width: 100%;
 }
 
 #new-btn {
@@ -131,6 +131,21 @@ h1 {
     width: 100%;
   }
 
+  .intro {
+    width: 95%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    row-gap: 10px;
+  }
+
+  .title {
+    width: 95%;
+    flex-direction: column;
+    align-items: center;
+    row-gap: 10px;
+  }
+
   /* game board that contains the grid of tiles */
   .game-board {
     margin-top: 30px;
@@ -142,7 +157,6 @@ h1 {
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
-    background-color: red;
   }
 
   /* cells on the game board */

--- a/src/2048-expert/index.html
+++ b/src/2048-expert/index.html
@@ -58,7 +58,7 @@
       </div>
       <!--Short introduction to game-->
       <div class="intro">
-        <strong>Challenge your limits!</strong> <a> Join cells, get to 2048</a>
+        <a><strong>Challenge your limits!</strong> Join cells, get to 2048</a>
         <button id="new-btn">New Game</button>
       </div>
       <div class="game-board"></div>


### PR DESCRIPTION
## Motivation

When narrowing down the browser window, the board sticks out of the page, past the length of the nav bar. This is not aesthetically pleasing and forces the user to have to scroll horizontally in order to see all parts of the board.

## Summary of changes

- centralized the information display (title, scores, intro, etc.)  for smaller screens
- reduced the size of the game board to fit within the entire screen for screens 700px wide or less

![image](https://user-images.githubusercontent.com/79767691/192949013-819c1326-221f-4f89-a44d-68fa81871839.png)

## Attached GitHub issue

Closes #123 

## Checklist

### Local Build
- [x] Ran all local tests `npm run test:ci`
- [x] Manually tested my solution

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR