### PR TITLE
fix: the score tracker for Tactong now increments only after a successful attempt by the user

### DIFF
--- a/src/tactong/index.js
+++ b/src/tactong/index.js
@@ -1,5 +1,5 @@
 ///// CONFIG VARIABLES /////
-const baseDifficulty = 0;
+const baseDifficulty = 1;
 const patternDelay = 500;
 const betweenPatternDelay = 100;
 
@@ -34,6 +34,7 @@ let pattern = [];
 let guess = [];
 let gameCount = 0;
 let bestScore = getBestScore() === null ? 0 : getBestScore();
+let isNewGame = true;
 
 function getRandomColor() {
     const colors = Object.keys(quadrants);
@@ -115,6 +116,7 @@ function checkEnd() {
 }
 
 function endGame() {
+    isNewGame = true;
     gameCount = 0;
     pattern = [];
     guess = [];
@@ -138,7 +140,7 @@ function updateScore() {
 
 function startNextGame() {
     stopHoverListeners();
-    gameCount++;
+    isNewGame ? isNewGame = false : gameCount++;
     updateScore();
     guess = [];
     pattern = generateRandomPattern(gameCount+baseDifficulty);


### PR DESCRIPTION
Previously, the score tracker for Tactong incremented at the start of every round, instead of after a successful attempt by the user. This PR removes that problem.

Closes #140 